### PR TITLE
feat: Add support for `dnf` package manager

### DIFF
--- a/.github/workflows/dnf.yml
+++ b/.github/workflows/dnf.yml
@@ -1,0 +1,116 @@
+name: dnf
+
+on:
+  pull_request:
+    branches: ["*"]
+    paths:
+      # Workflow file itself
+      - '.github/workflows/dnf.yml'
+      # Rust files
+      - '**.rs'
+      # Cargo files
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      # database
+      - "database.toml"
+  push:
+    branches: ["main", "develop"]
+    paths:
+      # Workflow file itself
+      - '.github/workflows/dnf.yml'
+      # Rust files
+      - '**.rs'
+      # Cargo files
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      # database
+      - "database.toml"
+  workflow_dispatch:
+
+concurrency:
+  # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
+  # On main, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
+  group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-{0}', github.ref) }}-${{github.workflow }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  dnf:
+    runs-on: ubuntu-latest
+    container:
+      image: ams21/cpkg-docker:${{ matrix.version }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        version:
+          # Alma Linux
+          - "almalinux-9"
+          - "almalinux-8"
+
+          # Amazon Linux
+          - "amazonlinux-2"
+          - "amazonlinux-1"
+          - "amazonlinux-2023"
+          - "amazonlinux-2022"
+          - "amazonlinux-2018.03"
+          - "amazonlinux-2017.12"
+          - "amazonlinux-2017.09"
+          - "amazonlinux-2017.03"
+          - "amazonlinux-2016.09"
+
+          # Fedora
+          - "fedora-41"
+          - "fedora-40"
+          - "fedora-39"
+          - "fedora-38"
+          - "fedora-37"
+          - "fedora-36"
+          - "fedora-35"
+          - "fedora-34"
+          - "fedora-33"
+          - "fedora-32"
+          - "fedora-31"
+          - "fedora-30"
+          - "fedora-29"
+          - "fedora-28"
+          - "fedora-27"
+          - "fedora-26"
+          - "fedora-25"
+          - "fedora-24"
+          - "fedora-23"
+          - "fedora-22"
+          - "fedora-21"
+
+          # Mageia
+          - "mageia-cauldron"
+          - "mageia-9"
+          - "mageia-8"
+          - "mageia-7"
+          - "mageia-6"
+
+          # Oracle Linux
+          - "oraclelinux-9"
+          - "oraclelinux-8"
+          - "oraclelinux-7"
+
+          # Photon OS
+          - "photonos-5"
+          - "photonos-4"
+          - "photonos-3"
+          - "photonos-2"
+          - "photonos-1"
+
+          # Rocky Linux
+          - "rockylinux-9"
+          - "rockylinux-8"
+
+    steps:
+      - name: Checkout
+        uses: taiki-e/checkout-action@v1
+
+      - name: Test
+        run: cargo test --no-default-features --features "dnf,_run_actual_installs_when_testing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,21 @@ clap_mangen = { version = "0.2.24", default-features = false }
 assert_cmd = { version = "2.0.16", default-features = false }
 
 [features]
-default = ["apt", "pamac"]
+default = ["apt", "dnf", "pamac"]
 
 # Package providers
 apt = []
+dnf = []
 pamac = []
+
+# Private features
+
+# NOTE: Do not enable this feature unless you know what you are doing.
+#       Because package managers like dnf do not support dry runs we use
+#       this feature to enable tests which run actual installations in CI.
+#       As this is obvoiusly not something you want to run on your actual system
+#       you should probably not enable this feature.
+_run_actual_installs_when_testing = []
 
 [profile.release]
 codegen-units = 1

--- a/database.toml
+++ b/database.toml
@@ -2,4 +2,5 @@
 
 [ccmake]
 apt = "cmake-curses-gui"
+dnf = "cmake"
 pamac = "cmake"

--- a/src/application.rs
+++ b/src/application.rs
@@ -3,5 +3,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, Default)]
 pub struct Application {
     pub apt: Option<String>,
+    pub dnf: Option<String>,
     pub pamac: Option<String>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,12 @@ pub enum Error {
         package_name: String,
     },
 
+    OptionNotSupported {
+        option_name: &'static str,
+        operation: &'static str,
+        provider: &'static str,
+    },
+
     // -- Internal errors --
     OsStringConversion {
         original: OsString,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,16 @@ fn handle_error(error: Error) -> i32 {
             EXIT_FAILURE
         }
 
+        Error::OptionNotSupported {
+            option_name,
+            operation,
+            provider,
+        } => {
+            eprintln!("Option '{option_name}' is not supported for '{operation}' by {provider}");
+
+            EXIT_FAILURE
+        }
+
         // -- Internal errors --
         #[allow(clippy::use_debug)]
         Error::OsStringConversion { .. }

--- a/src/provider/dnf.rs
+++ b/src/provider/dnf.rs
@@ -1,0 +1,141 @@
+use crate::application::Application;
+use crate::prelude::*;
+use crate::provider::Provider;
+use crate::subcommand::install;
+use crate::utility::command_to_full_string;
+use std::path::PathBuf;
+
+#[allow(clippy::module_name_repetitions)]
+pub struct DnfProvider {
+    executable_path: PathBuf,
+    installed: bool,
+}
+
+// NOTE: dnf cannot handle dry run for any operation
+
+impl DnfProvider {
+    fn run_command(&self, command_name: &str, packages: &[String], assume_yes: bool) -> Result<()> {
+        let mut command = std::process::Command::new(&self.executable_path);
+
+        command.arg(command_name);
+
+        // Now add all the translated package names
+        for package in packages {
+            command.arg(package);
+        }
+
+        // Add -y if assume_yes is true
+        if assume_yes {
+            command.arg("-y");
+        }
+
+        // Run the actual command
+        let return_code = command.spawn()?.wait()?;
+
+        if !return_code.success() {
+            return Err(Error::CommandFailed {
+                exit_code: return_code,
+                command_line: command_to_full_string(&command)?,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl Provider for DnfProvider {
+    fn name(&self) -> &'static str {
+        "dnf"
+    }
+
+    fn initialize() -> Self {
+        if cfg!(target_os = "linux") {
+            // First check for 'dnf'
+            if let Ok(dnf_path) = which::which("dnf") {
+                return Self {
+                    executable_path: dnf_path,
+                    installed: true,
+                };
+            }
+
+            // Then check for 'microdnf'
+            // https://github.com/rpm-software-management/microdnf
+            if let Ok(microdnf_path) = which::which("microdnf") {
+                return Self {
+                    executable_path: microdnf_path,
+                    installed: true,
+                };
+            }
+
+            // Finally check for 'tdnf'
+            // https://github.com/vmware/tdnf
+            if let Ok(tdnf_path) = which::which("tdnf") {
+                return Self {
+                    executable_path: tdnf_path,
+                    installed: true,
+                };
+            }
+        }
+
+        Self {
+            executable_path: PathBuf::new(),
+            installed: false,
+        }
+    }
+
+    fn is_installed(&self) -> bool {
+        self.installed
+    }
+
+    fn lookup_package(&self, application: &Application, package_name: &str) -> String {
+        if let Some(dnf_string) = &application.dnf {
+            return dnf_string.to_string();
+        }
+
+        package_name.to_owned()
+    }
+
+    fn install_packages(&self, packages: &[String], options: &install::Options) -> Result<()> {
+        if options.dry_run {
+            return Err(Error::OptionNotSupported {
+                option_name: "dry run",
+                operation: "install",
+                provider: self.name(),
+            });
+        }
+
+        self.run_command("install", packages, options.assume_yes)
+    }
+
+    fn remove_packages(
+        &self,
+        packages: &[String],
+        options: &crate::subcommand::remove::Options,
+    ) -> Result<()> {
+        if options.dry_run {
+            return Err(Error::OptionNotSupported {
+                option_name: "dry run",
+                operation: "remove",
+                provider: self.name(),
+            });
+        }
+
+        self.run_command("remove", packages, options.assume_yes)
+    }
+
+    fn reinstall_packages(
+        &self,
+        packages: &[String],
+        options: &crate::subcommand::reinstall::Options,
+    ) -> Result<()> {
+        if options.dry_run {
+            return Err(Error::OptionNotSupported {
+                option_name: "dry run",
+                operation: "reinstall",
+                provider: self.name(),
+            });
+        }
+
+        self.run_command("reinstall", packages, options.assume_yes)
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -6,6 +6,8 @@ use crate::subcommand::remove;
 
 #[cfg(feature = "apt")]
 pub mod apt;
+#[cfg(feature = "dnf")]
+pub mod dnf;
 #[cfg(feature = "pamac")]
 pub mod pamac;
 
@@ -35,6 +37,8 @@ pub fn get_all_providers() -> Vec<Box<dyn Provider>> {
     vec![
         #[cfg(feature = "apt")]
         Box::new(apt::AptProvider::initialize()),
+        #[cfg(feature = "dnf")]
+        Box::new(dnf::DnfProvider::initialize()),
         #[cfg(feature = "pamac")]
         Box::new(pamac::PamacProvider::initialize()),
     ]

--- a/src/provider/pamac.rs
+++ b/src/provider/pamac.rs
@@ -105,6 +105,14 @@ impl Provider for PamacProvider {
         packages: &[String],
         options: &crate::subcommand::reinstall::Options,
     ) -> Result<()> {
+        if options.dry_run {
+            return Err(Error::OptionNotSupported {
+                option_name: "dry run",
+                operation: "reinstall",
+                provider: self.name(),
+            });
+        }
+
         // NOTE: pamac's reinstall can't handle dry run
         self.run_command("reinstall", packages, options.assume_yes, false)
     }

--- a/tests/database.rs
+++ b/tests/database.rs
@@ -1,12 +1,21 @@
 use assert_cmd::Command;
 use cpkg::database::load_from_file;
-use cpkg::provider::get_number_of_installed_providers;
+use cpkg::provider::get_all_providers;
 
 #[test]
-fn all_packages_are_installable() {
+fn all_packages_are_dry_installable() {
+    let providers = get_all_providers();
+
     // No point in running this tests if no providers are installed
-    if get_number_of_installed_providers() == 0 {
+    if providers.is_empty() {
         return;
+    }
+
+    // The 'dnf' package manager cannot handle dry runs so skip the test if it's installed since it will cause an error here
+    for provider in providers {
+        if provider.name() == "dnf" {
+            return;
+        }
     }
 
     let database = load_from_file("database.toml").unwrap();
@@ -17,6 +26,31 @@ fn all_packages_are_installable() {
         cmd.arg("install");
         cmd.arg(package);
         cmd.arg("--dry-run");
+
+        cmd.assert().success();
+    }
+}
+
+// NOTE: See the note in Cargo.toml for the need of the '_run_actual_installs_when_testing' feature
+//       and why you probably don't want to run this test yourself.
+#[test]
+#[cfg(all(feature = "_run_actual_installs_when_testing", feature = "dnf"))]
+fn all_packages_are_installable() {
+    let providers = get_all_providers();
+
+    // Only run this test if the 'dnf' package manager is installed
+    if providers.len() != 1 || providers[0].name() != "dnf" {
+        return;
+    }
+
+    let database = load_from_file("database.toml").unwrap();
+
+    for package in database.packages.keys() {
+        let mut cmd = Command::cargo_bin("cpkg").unwrap();
+
+        cmd.arg("install");
+        cmd.arg(package);
+        cmd.arg("-y");
 
         cmd.assert().success();
     }


### PR DESCRIPTION
`dnf` is the newer package manager used by Fedora, Rocky Linux,
Red Hat Enterprise Linux and many others.

We also recognise `microdnf` as well as `tdnf` which should work
identically to `dnf`.

Sadly `dnf` does not support the dry-run option at all.